### PR TITLE
Add support for file flag with gulp test flag

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,6 @@
 var gulp = require('gulp');
 var $ = require('gulp-load-plugins')();
+var argv = require('yargs').argv;
 
 // Transpile ES6 source files into JavaScript
 gulp.task('build', function() {
@@ -26,7 +27,13 @@ gulp.task('serve', function() {
 // Run lab tests
 gulp.task('test', function() {
   'use strict';
-  return gulp.src(['test/**/*.js', 'test/mocks/*.js'])
+  
+  var testPath = ['test/**/*.js', 'test/mocks/*.js'];
+  if (argv.f) {
+    testPath = ['test/' + argv.f];
+  }
+  
+  return gulp.src(testPath)
     .pipe($.lab('-T node_modules/lab-babel'));
 });
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "gulp-load-plugins": "^0.10.0",
     "gulp-nodemon": "^2.0.2",
     "lab": "^5.8.0",
-    "lab-babel": "^1.0.0"
+    "lab-babel": "^1.0.0",
+    "yargs": "^3.30.0"
   },
   "dependencies": {
     "good": "^6.1.2",


### PR DESCRIPTION
Using yargs to add support for args in the test task.   This will look in the test folder for any file(s) that match the passed pattern or filename.
